### PR TITLE
Refactor to support missing required values in validation

### DIFF
--- a/api/src/1-core/Application/Common/Validation/FluentValidationExtensions.cs
+++ b/api/src/1-core/Application/Common/Validation/FluentValidationExtensions.cs
@@ -5,11 +5,29 @@ namespace SplitTheBill.Application.Common.Validation;
 
 internal static class FluentValidationExtensions
 {
+    internal static IRuleBuilderOptions<T, TProperty?> NotNullWithErrorCode<T, TProperty>(
+        this IRuleBuilder<T, TProperty?> ruleBuilder, string errorCode = ErrorCodes.Required)
+        => ruleBuilder
+            .NotNull()
+            .WithMessage(errorCode);
+
     internal static IRuleBuilderOptions<T, TProperty> NotEmptyWithErrorCode<T, TProperty>(
         this IRuleBuilder<T, TProperty> ruleBuilder, string errorCode = ErrorCodes.Required)
         => ruleBuilder
             .NotEmpty()
             .WithMessage(errorCode);
+
+    internal static IRuleBuilderOptions<T, Guid?> NotNullOrEmptyWithErrorCode<T>(
+        this IRuleBuilder<T, Guid?> ruleBuilder, 
+        string errorCodeWhenNull = ErrorCodes.Required,
+        string errorCodeWhenEmpty = ErrorCodes.Invalid)
+    {
+        return ruleBuilder
+            .NotNull()
+            .WithMessage(errorCodeWhenNull)
+            .Must(v => v.HasValue && v.Value != Guid.Empty)
+            .WithMessage(errorCodeWhenEmpty);
+    }
 
     internal static IRuleBuilderOptions<T, string?> ValidString<T>(this IRuleBuilder<T, string?> ruleBuilder,
         bool required,
@@ -32,7 +50,7 @@ internal static class FluentValidationExtensions
                     .GreaterThan(0))
             .WithMessage(ErrorCodes.Invalid);
 
-    internal static IRuleBuilderOptions<T, decimal> PositiveDecimal<T>(this IRuleBuilder<T, decimal> ruleBuilder,
+    internal static IRuleBuilderOptions<T, decimal?> PositiveDecimal<T>(this IRuleBuilder<T, decimal?> ruleBuilder,
         bool zeroInclusive)
         => (zeroInclusive
                 ? ruleBuilder

--- a/api/tests/Application.IntegrationTests/Modules/Groups/CreatePaymentTests.cs
+++ b/api/tests/Application.IntegrationTests/Modules/Groups/CreatePaymentTests.cs
@@ -17,14 +17,14 @@ internal sealed class CreatePaymentTests : ApplicationTestBase
     {
         var request = new CreatePaymentRequestBuilder()
             .WithGroupId(Guid.Empty)
-            .WithSendingMemberId(Guid.Empty)
+            .WithSendingMemberId(null)
             .WithReceivingMemberId(Guid.Empty)
-            .WithAmount(0m)
+            .WithAmount(-1)
             .Build();
         var result = await Application.SendAsync(request);
 
         result.IsError.ShouldBeTrue();
-        result.ErrorsOrEmptyList.Count.ShouldBeGreaterThanOrEqualTo(4);
+        result.ErrorsOrEmptyList.Count.ShouldBe(4);
         result.ErrorsOrEmptyList
             .ShouldContain(r =>
                 r.Type == ErrorType.Validation &&
@@ -34,7 +34,7 @@ internal sealed class CreatePaymentTests : ApplicationTestBase
             .ShouldContain(r =>
                 r.Type == ErrorType.Validation &&
                 r.Code == nameof(request.SendingMemberId) &&
-                r.Description == ErrorCodes.Invalid);
+                r.Description == ErrorCodes.Required);
         result.ErrorsOrEmptyList
             .ShouldContain(r =>
                 r.Type == ErrorType.Validation &&

--- a/api/tests/Application.Tests.Shared/Builders/CreatePaymentRequestBuilder.cs
+++ b/api/tests/Application.Tests.Shared/Builders/CreatePaymentRequestBuilder.cs
@@ -33,7 +33,6 @@ public sealed class CreatePaymentRequestBuilder
         return this;
     }
 
-    // public CreatePayment.Request Build() => new(_groupId, _sendingMemberId, _receivingMemberId, _amount);
     public CreatePayment.Request Build() => new()
     {
         GroupId = _groupId,

--- a/api/tests/Application.Tests.Shared/Builders/CreatePaymentRequestBuilder.cs
+++ b/api/tests/Application.Tests.Shared/Builders/CreatePaymentRequestBuilder.cs
@@ -4,35 +4,43 @@ namespace SplitTheBill.Application.Tests.Shared.Builders;
 
 public sealed class CreatePaymentRequestBuilder
 {
-    private Guid _groupId = Guid.NewGuid();
-    private Guid _sendingMemberId = Guid.NewGuid();
-    private Guid _receivingMemberId = Guid.NewGuid();
-    private decimal _amount = 0.0m;
+    private Guid? _groupId = null;
+    private Guid? _sendingMemberId = null;
+    private Guid? _receivingMemberId = null;
+    private decimal? _amount = null;
 
-    public CreatePaymentRequestBuilder WithGroupId(Guid groupId)
+    public CreatePaymentRequestBuilder WithGroupId(Guid? groupId)
     {
         _groupId = groupId;
         return this;
     }
 
-    public CreatePaymentRequestBuilder WithSendingMemberId(Guid sendingMemberId)
+    public CreatePaymentRequestBuilder WithSendingMemberId(Guid? sendingMemberId)
     {
         _sendingMemberId = sendingMemberId;
         return this;
     }
 
-    public CreatePaymentRequestBuilder WithReceivingMemberId(Guid receivingMemberId)
+    public CreatePaymentRequestBuilder WithReceivingMemberId(Guid? receivingMemberId)
     {
         _receivingMemberId = receivingMemberId;
         return this;
     }
 
-    public CreatePaymentRequestBuilder WithAmount(decimal amount)
+    public CreatePaymentRequestBuilder WithAmount(decimal? amount)
     {
         _amount = amount;
         return this;
     }
 
-    public CreatePayment.Request Build() => new(_groupId, _sendingMemberId, _receivingMemberId, _amount);
+    // public CreatePayment.Request Build() => new(_groupId, _sendingMemberId, _receivingMemberId, _amount);
+    public CreatePayment.Request Build() => new()
+    {
+        GroupId = _groupId,
+        SendingMemberId = _sendingMemberId,
+        ReceivingMemberId = _receivingMemberId,
+        Amount = _amount
+    };
+
     public static implicit operator CreatePayment.Request(CreatePaymentRequestBuilder builder) => builder.Build();
 }

--- a/api/tests/Application.UnitTests/Modules/Groups/CreatePaymentValidatorTests.cs
+++ b/api/tests/Application.UnitTests/Modules/Groups/CreatePaymentValidatorTests.cs
@@ -10,6 +10,19 @@ internal sealed class CreatePaymentValidatorTests
     private readonly CreatePayment.Validator _sut = new();
 
     [Test]
+    public void NullGroupId_Fails()
+    {
+        var request = new CreatePaymentRequestBuilder()
+            .WithGroupId(null)
+            .Build();
+        var result = _sut.TestValidate(request);
+
+        result
+            .ShouldHaveValidationErrorFor(r => r.GroupId)
+            .WithErrorMessage(ErrorCodes.Required);
+    }
+
+    [Test]
     public void EmptyGroupId_Fails()
     {
         var request = new CreatePaymentRequestBuilder()
@@ -32,6 +45,19 @@ internal sealed class CreatePaymentValidatorTests
 
         result
             .ShouldNotHaveValidationErrorFor(r => r.GroupId);
+    }
+    
+    [Test]
+    public void NullSendingMemberId_Fails()
+    {
+        var request = new CreatePaymentRequestBuilder()
+            .WithSendingMemberId(null)
+            .Build();
+        var result = _sut.TestValidate(request);
+
+        result
+            .ShouldHaveValidationErrorFor(r => r.SendingMemberId)
+            .WithErrorMessage(ErrorCodes.Required);
     }
 
     [Test]
@@ -57,6 +83,19 @@ internal sealed class CreatePaymentValidatorTests
 
         result
             .ShouldNotHaveValidationErrorFor(r => r.SendingMemberId);
+    }
+    
+    [Test]
+    public void NullReceivingMemberId_Fails()
+    {
+        var request = new CreatePaymentRequestBuilder()
+            .WithReceivingMemberId(null)
+            .Build();
+        var result = _sut.TestValidate(request);
+
+        result
+            .ShouldHaveValidationErrorFor(r => r.ReceivingMemberId)
+            .WithErrorMessage(ErrorCodes.Required);
     }
 
     [Test]
@@ -97,6 +136,19 @@ internal sealed class CreatePaymentValidatorTests
         result
             .ShouldHaveValidationErrorFor(r => r.ReceivingMemberId)
             .WithErrorMessage(ErrorCodes.NotUnique);
+    }
+    
+    [Test]
+    public void NullAmount_Fails()
+    {
+        var request = new CreatePaymentRequestBuilder()
+            .WithAmount(null)
+            .Build();
+        var result = _sut.TestValidate(request);
+
+        result
+            .ShouldHaveValidationErrorFor(r => r.Amount)
+            .WithErrorMessage(ErrorCodes.Required);
     }
 
     [Test]


### PR DESCRIPTION
When picking up a Request object from a JSON request body, missing properties resulted in exceptions from the JSON deserializer. By making the properties themselves nullable and validating them, we can still assume the values are not null in the handler (but have to use !.Value unfortunately), but also have proper ProblemDetails responses with e.g. "Required" error codes. 