### PR TITLE
Show list of groups & set up detail page

### DIFF
--- a/frontend/app/components/app/AppHeaderUserInfo.vue
+++ b/frontend/app/components/app/AppHeaderUserInfo.vue
@@ -56,6 +56,7 @@
 
 <script setup lang="ts">
 import type { MenuItem } from 'primevue/menuitem';
+import { getUpperCaseFirstLetter } from '#shared/utils';
 
 const menu = ref();
 const menuItems: MenuItem[] = [
@@ -77,7 +78,7 @@ const toggle = (event: Event) => {
 
 const { user, logout } = useOidcAuth();
 const name = computed<string | undefined>(() => user.value?.userInfo?.name as string);
-const label = computed<string>(() => name.value?.charAt(0).toUpperCase() ?? '');
+const label = computed(() => getUpperCaseFirstLetter(name));
 </script>
 
 <style scoped lang="scss">

--- a/frontend/app/components/common/AppPageBackButton.vue
+++ b/frontend/app/components/common/AppPageBackButton.vue
@@ -1,23 +1,48 @@
 <template>
-  <Button
-    class="back-button"
-    variant="text"
-    severity="secondary"
-    label="Back to overview"
-    icon="pi pi-arrow-left"
-  />
+  <NuxtLink :to="to">
+    <Button
+      class="back-button"
+      label="Back to overview"
+      icon="pi pi-arrow-left"
+      variant="text"
+      severity="secondary"
+    />
+  </NuxtLink>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import type { RouteLocationRaw } from '#vue-router';
+
+const props = defineProps<{
+  defaultRoute?: RouteLocationRaw;
+}>();
+const router = useRouter();
+const previousRoute = computed(() => router.options.history.state.back);
+
+const to = computed<RouteLocationRaw>(() => {
+  if (previousRoute.value) return { path: previousRoute.value as string };
+  if (props.defaultRoute) return props.defaultRoute;
+  return { name: 'index' };
+});
+</script>
 
 <style scoped lang="scss">
 @use '~/assets/styles/utilities';
 
 .back-button {
   margin-top: calc(var(--default-spacing) * -1);
+  margin-left: calc(var(--default-spacing) * -0.5);
 
-  @include utilities.media-max-lg {
-    margin-left: calc(var(--default-spacing) * -0.5);
+  &:hover,
+  &:active,
+  &:focus {
+    background: transparent !important;
+    color: var(--p-surface-600) !important;
+  }
+
+  &:active,
+  &:focus {
+    color: var(--p-surface-800) !important;
   }
 }
 </style>

--- a/frontend/app/components/common/AppPageBackButton.vue
+++ b/frontend/app/components/common/AppPageBackButton.vue
@@ -38,11 +38,17 @@ const to = computed<RouteLocationRaw>(() => {
   &:focus {
     background: transparent !important;
     color: var(--p-surface-600) !important;
+    @include utilities.dark-mode {
+      color: var(--p-surface-300) !important;
+    }
   }
 
   &:active,
   &:focus {
     color: var(--p-surface-800) !important;
+    @include utilities.dark-mode {
+      color: var(--p-surface-100) !important;
+    }
   }
 }
 </style>

--- a/frontend/app/components/groups/detail/GroupDetailRecentActivity.vue
+++ b/frontend/app/components/groups/detail/GroupDetailRecentActivity.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="recent-activity">
+    <h2>Recent activity</h2>
+    <Timeline
+      :value="activities"
+      class="timeline"
+    >
+      <template #content="slotProps">
+        <RecentActivityExpense
+          v-if="slotProps.item.type === 'Expense'"
+          :expense="slotProps.item"
+        />
+        <RecentActivityPayment
+          v-else-if="slotProps.item.type === 'Payment'"
+          :payment="slotProps.item"
+        />
+      </template>
+    </Timeline>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Group, Activity } from './types';
+import RecentActivityExpense from '~/components/groups/detail/RecentActivityExpense.vue';
+import RecentActivityPayment from '~/components/groups/detail/RecentActivityPayment.vue';
+
+const props = defineProps<{
+  group: Group;
+}>();
+
+const activities = computed<Activity[]>(() => {
+  const all = [
+    ...(props.group.expenses?.map((e) => ({ ...e, type: 'Expense' })) ?? []),
+    ...(props.group.payments?.map((p) => ({ ...p, type: 'Payment' })) ?? []),
+  ];
+  // sort by descending timestamp and take three most recent ones
+  return all
+    .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+    .slice(0, 3);
+});
+</script>
+
+<style scoped lang="scss">
+@use '~/assets/styles/utilities.scss';
+
+.recent-activity {
+  @include utilities.flex-column;
+
+  .timeline {
+    ::v-deep(.p-timeline-event-opposite) {
+      display: none;
+    }
+
+    ::v-deep(.p-timeline-event) {
+      min-height: 0;
+    }
+
+    ::v-deep(.p-timeline-event-content) {
+      margin-top: -0.1rem;
+      padding-bottom: var(--default-spacing);
+    }
+  }
+}
+</style>

--- a/frontend/app/components/groups/detail/RecentActivityExpense.vue
+++ b/frontend/app/components/groups/detail/RecentActivityExpense.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script setup lang="ts">
-import type { Expense } from './types';
+import type { Expense, GroupMember } from './types';
 import { formatTimestamp, formatCurrency } from '#shared/utils';
 
 const props = defineProps<{
@@ -20,5 +20,7 @@ const props = defineProps<{
 }>();
 
 const { getMember } = useGroupMembers();
-const paidByMember = computed(() => getMember(props.expense.paidByMemberId));
+const paidByMember = computed<GroupMember | undefined>(() =>
+  getMember(props.expense.paidByMemberId),
+);
 </script>

--- a/frontend/app/components/groups/detail/RecentActivityExpense.vue
+++ b/frontend/app/components/groups/detail/RecentActivityExpense.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="activity expense">
+    <div>
+      <strong>{{ expense.description }}: {{ formatCurrency(expense.amount) }}</strong>
+    </div>
+
+    paid by <strong>{{ paidByMember?.name }}</strong>
+    <div class="timestamp">
+      {{ formatTimestamp(expense.timestamp) }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Expense } from './types';
+import { formatTimestamp, formatCurrency } from '#shared/utils';
+
+const props = defineProps<{
+  expense: Expense;
+}>();
+
+const { getMember } = useGroupMembers();
+const paidByMember = computed(() => getMember(props.expense.paidByMemberId));
+</script>

--- a/frontend/app/components/groups/detail/RecentActivityPayment.vue
+++ b/frontend/app/components/groups/detail/RecentActivityPayment.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script setup lang="ts">
-import type { Payment } from './types';
+import type { GroupMember, Payment } from './types';
 import { formatTimestamp, formatCurrency } from '#shared/utils';
 
 const props = defineProps<{
@@ -22,6 +22,10 @@ const props = defineProps<{
 }>();
 
 const { getMember } = useGroupMembers();
-const sendingMember = computed(() => getMember(props.payment.sendingMemberId));
-const receivingMember = computed(() => getMember(props.payment.receivingMemberId));
+const sendingMember = computed<GroupMember | undefined>(() =>
+  getMember(props.payment.sendingMemberId),
+);
+const receivingMember = computed<GroupMember | undefined>(() =>
+  getMember(props.payment.receivingMemberId),
+);
 </script>

--- a/frontend/app/components/groups/detail/RecentActivityPayment.vue
+++ b/frontend/app/components/groups/detail/RecentActivityPayment.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="activity payment">
+    <div>
+      <strong>{{ sendingMember?.name }}</strong>
+      paid
+      <strong>{{ formatCurrency(payment.amount) }}</strong>
+      to
+      <strong>{{ receivingMember?.name }}</strong>
+    </div>
+    <div class="timestamp">
+      {{ formatTimestamp(payment.timestamp) }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Payment } from './types';
+import { formatTimestamp, formatCurrency } from '#shared/utils';
+
+const props = defineProps<{
+  payment: Payment;
+}>();
+
+const { getMember } = useGroupMembers();
+const sendingMember = computed(() => getMember(props.payment.sendingMemberId));
+const receivingMember = computed(() => getMember(props.payment.receivingMemberId));
+</script>

--- a/frontend/app/components/groups/detail/types.d.ts
+++ b/frontend/app/components/groups/detail/types.d.ts
@@ -1,0 +1,7 @@
+import type { BackendApiResponse } from '#open-fetch';
+
+export type Group = BackendApiResponse<'GetGroup'>;
+export type Expense = Group['expenses'][0] & { type: 'Expense' };
+export type Payment = Group['payments'][0] & { type: 'Payment' };
+export type Activity = Expense | Payment;
+export type GroupMember = Group['members'][0];

--- a/frontend/app/components/groups/overview/list/GroupsList.vue
+++ b/frontend/app/components/groups/overview/list/GroupsList.vue
@@ -1,10 +1,30 @@
 <template>
-  <ul>
-    <li>Group 1</li>
-    <li>Group 2</li>
-  </ul>
+  <div class="groups-list">
+    <ApiError
+      v-if="error"
+      :error="error"
+    />
+    <template v-if="status === 'pending'">
+      <GroupsListItemSkeleton
+        v-for="i in 3"
+        :key="i"
+      />
+    </template>
+    <GroupsListItem
+      v-for="group in groups"
+      :key="group.id"
+      :group="group"
+    />
+  </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import ApiError from '~/components/common/ApiError.vue';
+import GroupsListItem from '~/components/groups/overview/list/GroupsListItem.vue';
+import GroupsListItemSkeleton from '~/components/groups/overview/list/GroupsListItemSkeleton.vue';
+
+const { data, status, error } = useLazyBackendApi('/Groups', { key: 'groups' });
+const groups = computed(() => data.value?.groups);
+</script>
 
 <style scoped lang="scss"></style>

--- a/frontend/app/components/groups/overview/list/GroupsListItem.vue
+++ b/frontend/app/components/groups/overview/list/GroupsListItem.vue
@@ -1,0 +1,75 @@
+<template>
+  <NuxtLink
+    class="list-item"
+    :to="{ name: 'groups-id', params: { id: group.id } }"
+  >
+    <div class="left">
+      <Avatar
+        shape="circle"
+        :label="label"
+      />
+      <div class="name">{{ group.name }}</div>
+    </div>
+    <div class="right">
+      <i class="pi pi-arrow-right" />
+    </div>
+  </NuxtLink>
+</template>
+
+<script setup lang="ts">
+import type { Group } from './types';
+import { getUpperCaseFirstLetter } from '#shared/utils';
+
+const props = defineProps<{
+  group: Group;
+}>();
+const label = computed(() => getUpperCaseFirstLetter(props.group.name));
+</script>
+
+<style scoped lang="scss">
+@use '~/assets/styles/utilities';
+
+.list-item {
+  @include utilities.reset-link;
+  @include utilities.flex-row-justify-between-align-center;
+  margin-inline: calc(var(--default-spacing) * -1);
+  padding: var(--default-spacing);
+  &:not(:last-child) {
+    border-bottom: 1px solid var(--p-surface-200);
+  }
+
+  .pi {
+    color: var(--p-surface-500);
+    @include utilities.dark-mode {
+      color: var(--p-surface-400);
+    }
+  }
+
+  &:hover {
+    transition: background 0.2s;
+
+    background-color: var(--p-surface-100);
+    @include utilities.dark-mode {
+      background-color: var(--p-surface-800);
+    }
+
+    .pi {
+      transition: all 0.1s;
+      translate: -0.25rem;
+      color: var(--p-surface-800);
+
+      @include utilities.dark-mode {
+        color: var(--p-surface-0);
+      }
+    }
+  }
+
+  @include utilities.dark-mode {
+    border-bottom-color: var(--p-surface-700);
+  }
+
+  .left {
+    @include utilities.flex-row-justify-between-align-center;
+  }
+}
+</style>

--- a/frontend/app/components/groups/overview/list/GroupsListItem.vue
+++ b/frontend/app/components/groups/overview/list/GroupsListItem.vue
@@ -39,10 +39,7 @@ const label = computed(() => getUpperCaseFirstLetter(props.group.name));
   }
 
   .pi {
-    color: var(--p-surface-500);
-    @include utilities.dark-mode {
-      color: var(--p-surface-400);
-    }
+    color: var(--p-surface-400);
   }
 
   &:hover {
@@ -56,7 +53,7 @@ const label = computed(() => getUpperCaseFirstLetter(props.group.name));
     .pi {
       transition: all 0.1s;
       translate: -0.25rem;
-      color: var(--p-surface-800);
+      color: var(--p-surface-600);
 
       @include utilities.dark-mode {
         color: var(--p-surface-0);

--- a/frontend/app/components/groups/overview/list/GroupsListItemSkeleton.vue
+++ b/frontend/app/components/groups/overview/list/GroupsListItemSkeleton.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="list-item">
+    <div class="left">
+      <Skeleton
+        shape="circle"
+        size="2rem"
+      />
+      <Skeleton
+        width="10rem"
+        height="1.25rem"
+      />
+    </div>
+    <div class="right">
+      <i class="pi pi-arrow-right" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts"></script>
+
+<style scoped lang="scss">
+@use '~/assets/styles/utilities';
+
+.list-item {
+  @include utilities.flex-row-justify-between-align-center;
+  margin-inline: calc(var(--default-spacing) * -1);
+  padding: var(--default-spacing);
+  &:not(:last-child) {
+    border-bottom: 1px solid var(--p-surface-200);
+  }
+
+  .pi {
+    color: var(--p-surface-300);
+  }
+
+  &:hover {
+    transition: background 0.2s;
+
+    background-color: var(--p-surface-100);
+    @include utilities.dark-mode {
+      background-color: var(--p-surface-800);
+    }
+  }
+
+  @include utilities.dark-mode {
+    border-bottom-color: var(--p-surface-700);
+    .pi {
+      color: var(--p-surface-700);
+    }
+  }
+
+  .left {
+    @include utilities.flex-row-justify-between-align-center;
+  }
+}
+</style>

--- a/frontend/app/components/groups/overview/list/types.d.ts
+++ b/frontend/app/components/groups/overview/list/types.d.ts
@@ -1,0 +1,3 @@
+import type { BackendApiResponse } from '#open-fetch';
+
+export type Group = BackendApiResponse<'GetGroups'>['groups'][0];

--- a/frontend/app/composables/useGroupMembers.ts
+++ b/frontend/app/composables/useGroupMembers.ts
@@ -1,0 +1,15 @@
+import type { Group, GroupMember } from '~/components/groups/detail/types';
+
+const useGroupMembers = () => {
+  const group = inject<ComputedRef<Group>>('group');
+  const members = computed<GroupMember[]>(() => group?.value?.members ?? []);
+
+  const getMember = (id: string): GroupMember => members.value?.find((m) => m.id === id);
+
+  return {
+    members,
+    getMember,
+  };
+};
+
+export default useGroupMembers;

--- a/frontend/app/composables/useGroupMembers.ts
+++ b/frontend/app/composables/useGroupMembers.ts
@@ -4,7 +4,8 @@ const useGroupMembers = () => {
   const group = inject<ComputedRef<Group>>('group');
   const members = computed<GroupMember[]>(() => group?.value?.members ?? []);
 
-  const getMember = (id: string): GroupMember => members.value?.find((m) => m.id === id);
+  const getMember = (id: string): GroupMember | undefined =>
+    members.value?.find((m) => m.id === id);
 
   return {
     members,

--- a/frontend/app/pages/groups/[id].vue
+++ b/frontend/app/pages/groups/[id].vue
@@ -9,7 +9,11 @@
       />
       <template v-if="group">
         <h1>{{ group.name }}</h1>
-        <PreformattedText :value="group" />
+        <GroupDetailRecentActivity :group="group" />
+        <PreformattedText
+          v-if="false"
+          :value="group"
+        />
       </template>
     </AppPageMain>
   </div>
@@ -21,6 +25,7 @@ import AppPageBackButton from '~/components/common/AppPageBackButton.vue';
 import ApiError from '~/components/common/ApiError.vue';
 import LoadingIndicator from '~/components/common/LoadingIndicator.vue';
 import PreformattedText from '~/components/common/PreformattedText.vue';
+import GroupDetailRecentActivity from '~/components/groups/detail/GroupDetailRecentActivity.vue';
 
 const route = useRoute();
 const groupId = route.params.id as string;
@@ -30,4 +35,5 @@ const {
   status,
   error,
 } = await useLazyBackendApi('/Groups/{id}', { key, path: { id: groupId } });
+provide('group', readonly(group));
 </script>

--- a/frontend/app/pages/groups/[id].vue
+++ b/frontend/app/pages/groups/[id].vue
@@ -1,6 +1,6 @@
 <template>
   <div class="group-detail-page">
-    <AppPageBackButton />
+    <AppPageBackButton :default-route="{ name: 'groups' }" />
     <AppPageMain>
       <h1>{{ groupId }}</h1>
     </AppPageMain>

--- a/frontend/app/pages/groups/[id].vue
+++ b/frontend/app/pages/groups/[id].vue
@@ -2,7 +2,15 @@
   <div class="group-detail-page">
     <AppPageBackButton :default-route="{ name: 'groups' }" />
     <AppPageMain>
-      <h1>{{ groupId }}</h1>
+      <LoadingIndicator v-if="status === 'pending'" />
+      <ApiError
+        v-if="error"
+        :error="error"
+      />
+      <template v-if="group">
+        <h1>{{ group.name }}</h1>
+        <PreformattedText :value="group" />
+      </template>
     </AppPageMain>
   </div>
 </template>
@@ -10,7 +18,16 @@
 <script setup lang="ts">
 import AppPageMain from '~/components/app/AppPageMain.vue';
 import AppPageBackButton from '~/components/common/AppPageBackButton.vue';
+import ApiError from '~/components/common/ApiError.vue';
+import LoadingIndicator from '~/components/common/LoadingIndicator.vue';
+import PreformattedText from '~/components/common/PreformattedText.vue';
 
 const route = useRoute();
 const groupId = route.params.id as string;
+const key = computed(() => `groups/${groupId}`);
+const {
+  data: group,
+  status,
+  error,
+} = await useLazyBackendApi('/Groups/{id}', { key, path: { id: groupId } });
 </script>

--- a/frontend/app/pages/groups/index.vue
+++ b/frontend/app/pages/groups/index.vue
@@ -1,7 +1,15 @@
 <template>
   <div class="groups-page">
     <AppPageMain class="main">
-      <h1>Groups</h1>
+      <div class="header">
+        <h1>Groups</h1>
+        <div class="actions">
+          <Button
+            label="Create group"
+            icon="pi pi-plus"
+          />
+        </div>
+      </div>
       <GroupsList />
     </AppPageMain>
   </div>
@@ -17,5 +25,9 @@ import GroupsList from '~/components/groups/overview/list/GroupsList.vue';
 
 .main {
   @include utilities.flex-column;
+}
+
+.header {
+  @include utilities.flex-row-justify-between-align-center;
 }
 </style>

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -41,7 +41,7 @@ export default defineNuxtConfig({
   },
   routeRules: {
     // route to the groups overview by default
-    // '/': { redirect: '/groups' },
+    '/': { redirect: '/groups' },
   },
   oidc: {
     defaultProvider: 'oidc',

--- a/frontend/shared/utils.ts
+++ b/frontend/shared/utils.ts
@@ -5,3 +5,15 @@
  */
 export const stringIsNullOrWhitespace = (value: string | null | undefined): boolean =>
   !value || !value.trim();
+
+export const getUpperCaseFirstLetter = (
+  value:
+    | string
+    | null
+    | undefined
+    | Ref<string | null | undefined>
+    | ComputedRef<string | null | undefined>,
+): string => {
+  const str = unref(value);
+  return str?.charAt(0).toUpperCase() ?? '';
+};

--- a/frontend/shared/utils.ts
+++ b/frontend/shared/utils.ts
@@ -17,3 +17,22 @@ export const getUpperCaseFirstLetter = (
   const str = unref(value);
   return str?.charAt(0).toUpperCase() ?? '';
 };
+
+export const formatTimestamp = (timestamp: string | number): string => {
+  const date = new Date(timestamp);
+  return date.toLocaleString('nl-BE', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+};
+
+export const formatCurrency = (value: number) => {
+  return new Intl.NumberFormat('nl-BE', {
+    style: 'currency',
+    currency: 'EUR',
+  }).format(value);
+};


### PR DESCRIPTION
* Fetch groups from the backend API
* Show them in a list on the overview page
* Set up group detail page
  * Initial "recent activity" implementation
  * Fetch group from API and use provide-inject to avoid prop drilling
* UI improvements